### PR TITLE
Fixed error with setWindowTitle syntax

### DIFF
--- a/evalys/visu/core.py
+++ b/evalys/visu/core.py
@@ -99,7 +99,7 @@ class EvalysLayout:
 
     @wtitle.setter
     def wtitle(self, wtitle):
-        self.fig.canvas.set_window_title(wtitle)
+        self.fig.canvas.setWindowTitle(wtitle)
 
 
 class SimpleLayout(EvalysLayout):


### PR DESCRIPTION
When running example1.py, an error is returned that there is no function set_window_title, and that error suggests that the user should try setWindowTitle instead. Changing set_window_title to setWindowTitle fixes the issue and allows example1.py to run. 