### PR TITLE
Added the ability to export a jobset to a dataframe

### DIFF
--- a/evalys/jobset.py
+++ b/evalys/jobset.py
@@ -144,6 +144,20 @@ class JobSet(object):
             df.to_csv(f, index=False, sep=",",
                       float_format='%.{}f'.format(self.float_precision))
 
+    def to_df(self):
+        """ Export this jobset to a dataframe
+        
+        Example:
+        >>> from evalys.jobset import JobSet
+        >>> js = JobSet.from_csv("./examples/jobs.csv")
+        >>> df = js.to_df()
+        >>> print(df)
+        
+        """
+        df = self.df.copy()
+        df.allocated_resources = df.allocated_resources.apply(str)
+        return df
+
     def gantt(self, time_scale=False, **kwargs):
         if time_scale:
             kwargs['xscale'] = 'time'


### PR DESCRIPTION
I'm working on using evalys to script the creation of a number of Gantt charts based on certain parameters. Through the course of my project, I ran into the issue of not being able to interact with jobsets in several ways that I typically interact with data frames. As such, I wrote this function which allows the user to export a jobset into a data frame directly, so that they can retain identical structure and datatypes as their original jobset,  without having to first export it to CSV, then convert the CSV back into a data frame.