### PR TITLE
[fix] deprecated pandas method .append, #15

### DIFF
--- a/evalys/jobset.py
+++ b/evalys/jobset.py
@@ -244,8 +244,7 @@ class JobSet(object):
         stop_event_df.columns = event_columns
 
         # merge events and sort them
-        event_df = start_event_df.append(
-            stop_event_df,
+        event_df = pd.concat([start_event_df, stop_event_df],
             ignore_index=True).sort_values(
                 by=['time', 'grab']).reset_index(drop=True)
 

--- a/evalys/metrics.py
+++ b/evalys/metrics.py
@@ -65,8 +65,7 @@ def compute_load(dataframe, col_begin, col_end, col_cumsum,
     stop_event_df.columns = event_columns
 
     # merge events and sort them
-    event_df = start_event_df.append(
-        stop_event_df,
+    event_df = pd.concat([start_event_df, stop_event_df],
         ignore_index=True).sort_values(by='time').reset_index(drop=True)
 
     # sum the event that happend at the same time and cummulate events

--- a/evalys/pstates.py
+++ b/evalys/pstates.py
@@ -44,7 +44,7 @@ class PowerStatesChanges(object):
 
         finish_df = pd.DataFrame(index=[0], columns=['time', 'machine_id', 'new_pstate'])
         finish_df.iloc[0] = [float('inf'), all_machines_str, 42]
-        df = df.append(finish_df)
+        df = pd.concat([df, finish_df])
 
         # Let's traverse the dataframe to create rectangles
         after_init = df.loc[df['time'] > 0]


### PR DESCRIPTION
There are a couple other uses of `Dataframe.append` in the code, but I didn't want to mess up too much as it is in parts of the code that I don't use myself...