### PR TITLE
fix: deprecated delim_whitespace in the pd.read_csv() function

### DIFF
--- a/evalys/workload.py
+++ b/evalys/workload.py
@@ -209,7 +209,7 @@ class Workload(object):
                        'command', 'queue', 'name', 'array', 'type', 'reservation', 'cigri_id']
             
         df_tmp = pd.read_csv(filename, comment=';', names=columns,
-                         header=0, delim_whitespace=True)
+                         header=0, sep='\s+')
 
         if file_extension == 'owf':
             # 


### PR DESCRIPTION
There is a deprecated parameter that represents a "FutureWarning" caused by removed features. However, I fixed the delim_whitespace parameter to use the sep parameter.

- FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead

Please refer the following link: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html

delim_whitespace [bool, default False]: Deprecated since version 2.2.0: Use sep="\s+" instead.

